### PR TITLE
Add sequence number to observed frame definition.

### DIFF
--- a/draft-seemann-quic-address-discovery.md
+++ b/draft-seemann-quic-address-discovery.md
@@ -137,7 +137,7 @@ Port:
 
 : The port number, in network byte order.
 
-This frame MUST only appear in the application data packet
+This frame MUST only appear in the handshake and in the application data packet
 number space. It is a "probing frame" as defined in {{Section 9.1 of RFC9000}}.
 OBSERVED_ADDRESS frames are ack-eliciting, and SHOULD be retransmitted if lost.
 Retransmissions MUST happen on the same path as the original frame was sent on.


### PR DESCRIPTION
Add a sequence number to the observed address frame, using the same format as previous drafts, and explain how this monotonically increasing sequence number is used to avoid acting on duplicated or delayed packets. Also strikes out the reference to handshake packets.

Close #17